### PR TITLE
pom.xml增加commons-collections依赖

### DIFF
--- a/dubbo-admin/pom.xml
+++ b/dubbo-admin/pom.xml
@@ -146,6 +146,11 @@
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
citrus-webx-all中com.alibaba.citrus.service.velocity.impl.VelocityRuntimeInstance用到了ExtendedProperties,但是未引入，导致在tomcat启动报错

## What is the purpose of the change

保证dubbo-admin2.5.8正常启动

## Brief changelog

在dubbo-admin的pom.xml 增加依赖jar包引入
        <dependency>
            <groupId>commons-collections</groupId>
            <artifactId>commons-collections</artifactId>
            <version>3.2.2</version>
        </dependency>


## Verifying this change
